### PR TITLE
Update package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     ]
   },
   "devDependencies": {
-    "kerosene": "http://gitlab.com/fetchsky/kerosene",
+    "kerosene": "https://gitlab.com/fetchsky/kerosene.git",
     "please-upgrade-node": "^3.2.0"
   }
 }


### PR DESCRIPTION
I get an error(TAR ENTRY INVALID) when using node version 18. I downgrade the node version to 16. I get 'package.json' not found about dev dependency.
Converting HTTP URL to HTTPS URL solves the problem.